### PR TITLE
feat: add BSC mainnet OAR

### DIFF
--- a/lib-experimental/oraclizeAPI_lib.sol
+++ b/lib-experimental/oraclizeAPI_lib.sol
@@ -357,6 +357,9 @@ library oraclizeLib {
         if (getCodeSize(0x146500cfd35B22E4A392Fe0aDc06De1a1368Ed48)>0){ //rinkeby testnet
             return OraclizeAddrResolverI(0x146500cfd35B22E4A392Fe0aDc06De1a1368Ed48);
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84)>0){ //bsc mainnet
+            return OraclizeAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475)>0){ //ethereum-bridge
             return OraclizeAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
         }

--- a/oraclizeAPI_0.4.25.sol
+++ b/oraclizeAPI_0.4.25.sol
@@ -347,6 +347,11 @@ contract usingOraclize {
             oraclize_setNetworkName("eth_goerli");
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84)>0){ //bsc mainnet
+            OAR = OraclizeAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            oraclize_setNetworkName("bsc_mainnet");
+            return true;
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475)>0){ //ethereum-bridge
             OAR = OraclizeAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
             return true;

--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -347,6 +347,11 @@ contract usingOraclize {
             oraclize_setNetworkName("eth_goerli");
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84)>0){ //bsc mainnet
+            OAR = OraclizeAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            oraclize_setNetworkName("bsc_mainnet");
+            return true;
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475)>0){ //ethereum-bridge
             OAR = OraclizeAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
             return true;

--- a/oraclizeAPI_0.5.sol
+++ b/oraclizeAPI_0.5.sol
@@ -354,6 +354,11 @@ contract usingOraclize {
             oraclize_setNetworkName("eth_goerli");
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84) > 0){ //bsc mainnet
+            OAR = OraclizeAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            oraclize_setNetworkName("bsc_mainnet");
+            return true;
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475) > 0) { //ethereum-bridge
             OAR = OraclizeAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
             return true;

--- a/oraclizeAPI_pre0.4.sol
+++ b/oraclizeAPI_pre0.4.sol
@@ -87,6 +87,10 @@ contract usingOraclize {
             OAR = OraclizeAddrResolverI(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1);
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84)>0){ //bsc mainnet
+            OAR = OraclizeAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            return true;
+        }
         if (getCodeSize(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa)>0){ //browser-solidity
             OAR = OraclizeAddrResolverI(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa);
             return true;

--- a/provableAPI_0.4.25.sol
+++ b/provableAPI_0.4.25.sol
@@ -347,6 +347,11 @@ contract usingProvable {
             provable_setNetworkName("eth_goerli");
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84)>0){ //bsc mainnet
+            OAR = OracleAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            provable_setNetworkName("bsc_mainnet");
+            return true;
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475)>0){ //ethereum-bridge
             OAR = OracleAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
             return true;

--- a/provableAPI_0.5.sol
+++ b/provableAPI_0.5.sol
@@ -355,6 +355,11 @@ contract usingProvable {
             provable_setNetworkName("eth_goerli");
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84) > 0){ //bsc mainnet
+            OAR = OracleAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            provable_setNetworkName("bsc_mainnet");
+            return true;
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475) > 0) { //ethereum-bridge
             OAR = OracleAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
             return true;

--- a/provableAPI_0.6.sol
+++ b/provableAPI_0.6.sol
@@ -337,6 +337,11 @@ contract usingProvable {
             provable_setNetworkName("eth_goerli");
             return true;
         }
+        if (getCodeSize(0x90A0F94702c9630036FB9846B52bf31A1C991a84) > 0){ //bsc mainnet
+            OAR = OracleAddrResolverI(0x90A0F94702c9630036FB9846B52bf31A1C991a84);
+            provable_setNetworkName("bsc_mainnet");
+            return true;
+        }
         if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475) > 0) { //ethereum-bridge
             OAR = OracleAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
             return true;


### PR DESCRIPTION
At the moment, contract deployment would fail for BSC, without explicitly setting OAR.
This PR updates the API by adding the OAR setting for BSC.
The additional line `oraclize_setNetworkName("bsc_mainnet");` should be required for Ledger Proof. Need to test this.